### PR TITLE
Perf boost

### DIFF
--- a/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
+++ b/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
@@ -5,8 +5,36 @@ from petsc4py import PETSc
 import arrayfire as af
 import numpy as np
 from numpy.fft import fftfreq
-import sys
+import pylab as pl
 
+pl.rcParams['figure.figsize']  = 17, 7.5
+pl.rcParams['figure.dpi']      = 150
+pl.rcParams['image.cmap']      = 'jet'
+pl.rcParams['lines.linewidth'] = 1.5
+pl.rcParams['font.family']     = 'serif'
+pl.rcParams['font.weight']     = 'bold'
+pl.rcParams['font.size']       = 20
+pl.rcParams['font.sans-serif'] = 'serif'
+pl.rcParams['text.usetex']     = True
+pl.rcParams['axes.linewidth']  = 1.5
+pl.rcParams['axes.titlesize']  = 'medium'
+pl.rcParams['axes.labelsize']  = 'medium'
+
+pl.rcParams['xtick.major.size'] = 8
+pl.rcParams['xtick.minor.size'] = 4
+pl.rcParams['xtick.major.pad']  = 8
+pl.rcParams['xtick.minor.pad']  = 8
+pl.rcParams['xtick.color']      = 'k'
+pl.rcParams['xtick.labelsize']  = 'medium'
+pl.rcParams['xtick.direction']  = 'in'
+
+pl.rcParams['ytick.major.size'] = 8
+pl.rcParams['ytick.minor.size'] = 4
+pl.rcParams['ytick.major.pad']  = 8
+pl.rcParams['ytick.minor.pad']  = 8
+pl.rcParams['ytick.color']      = 'k'
+pl.rcParams['ytick.labelsize']  = 'medium'
+pl.rcParams['ytick.direction']  = 'in'
 
 class poisson_eqn(object):
     """
@@ -22,6 +50,9 @@ class poisson_eqn(object):
         self.obj       = nonlinear_solver_obj
         self.local_phi = self.da.createLocalVec() # phi with ghost zones
         self.N_ghost   = self.obj.N_ghost
+        self.dq1       = self.obj.dq1
+        self.dq2       = self.obj.dq2
+        self.density   = 0.
 
         ((i_q1_start, i_q2_start), (N_q1_local, N_q2_local)) = \
                 self.da.getCorners()
@@ -36,7 +67,7 @@ class poisson_eqn(object):
         N_g = self.N_ghost
 
 	# Residual assembly using numpy
-        phi_array = self.local_phi.getArray(readonly=1)
+        phi_array = self.local_phi.getArray(readonly=0)
         phi_array = phi_array.reshape([self.N_q2_local + 2*N_g, \
                                        self.N_q1_local + 2*N_g, 1], \
                                       order='A'
@@ -48,7 +79,37 @@ class poisson_eqn(object):
                                                 order='A'
                                                )
 
-        residual_array[:, :, :] = phi_array[N_g:-N_g, N_g:-N_g, :]**2. - 2.
+        #phi_array[:N_g,                 :] = 0.
+        #phi_array[self.N_q2_local+N_g:, :] = 0.
+        #phi_array[:,                 :N_g] = 0.
+        #phi_array[:, self.N_q1_local+N_g:] = 0.
+
+        phi_plus_x  = np.roll(phi_array, shift=-1, axis=1)
+        phi_minus_x = np.roll(phi_array, shift=1,  axis=1)
+        phi_plus_y  = np.roll(phi_array, shift=-1, axis=0)
+        phi_minus_y = np.roll(phi_array, shift=1,  axis=0)
+
+        d2phi_dx2   = (phi_minus_x - 2.*phi_array + phi_plus_x)/self.dq1**2.
+        d2phi_dy2   = (phi_minus_y - 2.*phi_array + phi_plus_y)/self.dq2**2.
+	
+        laplacian_phi = d2phi_dx2 + d2phi_dy2
+
+        density_af = af.moddims(self.density,
+                                  (self.N_q1_local+2*N_g)
+                                * (self.N_q2_local+2*N_g)
+                               )
+        density_np = density_af.to_ndarray()
+        density_np = density_np.reshape([self.N_q2_local + 2*N_g, \
+                                         self.N_q1_local + 2*N_g, 1], \
+                                        order='A'
+                                       )
+
+        residual_array[:, :] = \
+            (laplacian_phi + density_np)[N_g:-N_g, N_g:-N_g]
+
+#        residual_array[:, :] = \
+#            (laplacian_phi + self.density)[N_g:-N_g, N_g:-N_g]
+
 
 	# Residual assembly using arrayfire
 #        phi_array    = self.local_phi.getArray(readonly=1)
@@ -77,6 +138,8 @@ def compute_electrostatic_fields(self, performance_test_flag = False):
     # (lowest values of the canonical coordinates in the local zone)
     # Additionally, we also obtain the size of the local zone
     ((i_q1_start, i_q2_start), (N_q1_local, N_q2_local)) = self._da_snes.getCorners()
+    
+    N_g = self.N_ghost
 
     snes = PETSc.SNES().create()
     pde  = poisson_eqn(self)
@@ -84,81 +147,80 @@ def compute_electrostatic_fields(self, performance_test_flag = False):
     
     snes.setDM(self._da_snes)
     snes.setFromOptions()
+    pde.density = self.compute_moments('density')
     snes.solve(None, self.glob_phi)
     
-    phi_array = self.glob_phi.getArray()
-    print("phi = ", phi_array)
+    #phi_array = self.glob_phi.getArray()
+    #print("phi = ", phi_array)
+    #phi_array = phi_array.reshape([N_q2_local, \
+    #                               N_q1_local, 1], \
+    #                              order='A'
+    #                             )
 
-    
-
-#    pde = Poisson2D(self)
-#    phi = self._da_ksp.createGlobalVec()
-#    rho = self._da_ksp.createGlobalVec()
-#
-#    phi_local = self._da_ksp.createLocalVec()
-#
-#    A = PETSc.Mat().createPython([phi.getSizes(), rho.getSizes()],
-#                                 comm=self._da_ksp.comm
-#                                )
-#    A.setPythonContext(pde)
-#    A.setUp()
-#
-#    ksp = PETSc.KSP().create()
-#
-#    ksp.setOperators(A)
-#    ksp.setType('cg')
-#
-#    pc = ksp.getPC()
-#    pc.setType('none')
-#
-#    N_g = self.N_ghost
-#    ksp.setTolerances(atol=1e-7)
-#    pde.RHS(rho,
-#              self.physical_system.params.charge_electron
-#            * np.array(self.compute_moments('density')[N_g:-N_g,
-#                                                       N_g:-N_g
-#                                                      ]
-#                       - 1
-#                      )
-#           )
-#
-#    ksp.setFromOptions()
-#    ksp.solve(rho, phi)
-#
-#    num_tries = 0
-#    while(ksp.converged is not True):
-#        
-#        ksp.setTolerances(atol = 10**(-6+num_tries), rtol = 10**(-6+num_tries))
-#        ksp.solve(rho, phi)
-#        num_tries += 1
-#        
-#        if(num_tries == 5):
-#            raise Exception('KSP solver diverging!')
-#
-#    self._da_ksp.globalToLocal(phi, phi_local)
-
-#    # Since rho was defined at (i + 0.5, j + 0.5)
-#    # Electric Potential returned will also be at (i + 0.5, j + 0.5)
-#    electric_potential = af.to_array(np.swapaxes(phi_local[:].
-#                                                 reshape(  N_q2_local
-#                                                         + 2 * self.N_ghost,
-#                                                           N_q1_local +
-#                                                         + 2 * self.N_ghost
-#                                                        ),
+    self._da_snes.globalToLocal(self.glob_phi, pde.local_phi)
+    phi_local_array = pde.local_phi.getArray()
+    electric_potential = af.to_array(phi_local_array)
+    phi_local_array = phi_local_array.reshape([N_q2_local + 2*N_g, \
+                                               N_q1_local + 2*N_g], \
+                                             )
+    density_af = af.moddims(pde.density,
+                              (N_q1_local+2*N_g)
+                            * (N_q2_local+2*N_g)
+                           )
+    density_np = density_af.to_ndarray()
+    density_np = density_np.reshape([N_q2_local + 2*N_g, \
+                                     N_q1_local + 2*N_g], \
+                                   )
+    # Since rho was defined at (i + 0.5, j + 0.5)
+    # Electric Potential returned will also be at (i + 0.5, j + 0.5)
+#    electric_potential = af.to_array(np.swapaxes(phi_local_array,
 #                                                 0, 1
 #                                                )
 #                                    )
-#
-#    # Obtaining the values at (i+0.5, j+0.5):
-#    self.E1 = -(  af.shift(electric_potential, -1)
-#                - af.shift(electric_potential,  1)
-#               ) / (2 * self.dq1)
-#
-#    self.E2 = -(  af.shift(electric_potential, 0, -1)
-#                - af.shift(electric_potential, 0,  1)
-#               ) / (2 * self.dq2)
-#
-#    af.eval(self.E1, self.E2)
+
+    electric_potential = af.moddims(electric_potential,
+                                    N_q1_local + 2*N_g,
+                                    N_q2_local + 2*N_g
+                                   )
+
+    # Obtaining the values at (i+0.5, j+0.5):
+    self.E1 = -(  af.shift(electric_potential, -1)
+                - af.shift(electric_potential,  1)
+               ) / (2 * self.dq1)
+
+    self.E2 = -(  af.shift(electric_potential, 0, -1)
+                - af.shift(electric_potential, 0,  1)
+               ) / (2 * self.dq2)
+
+    af.eval(self.E1, self.E2)
+
+    q2_minus = 0.25
+    q2_plus  = 0.75
+
+    E2_expected = -0.5/20 * (  af.log(af.cosh(( self.q2 - q2_minus)*20)) 
+                             - af.log(af.cosh(( self.q2 - q2_plus )*20))
+                            ) 
+
+    pl.subplot(121)
+    pl.contourf(
+                #np.array(self.E2)[N_g:-N_g, N_g:-N_g], 100
+                density_np[N_g:-N_g, N_g:-N_g], 100
+               )
+    pl.colorbar()
+    #pl.axis('equal')
+    pl.title(r'Density')
+    #pl.title(r'$E^2_{numerical}$')
+    pl.subplot(122)
+    pl.contourf(
+                #np.array(E2_expected)[N_g:-N_g, N_g:-N_g], 100
+                phi_local_array[N_g:-N_g, N_g:-N_g], 100
+               )
+    pl.colorbar()
+    pl.title(r'$\phi$')
+    #pl.title(r'$E^2_{analytic}$')
+    #pl.axis('equal')
+    pl.show()
+
 
     if(performance_test_flag == True):
         af.sync()

--- a/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
+++ b/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
@@ -152,7 +152,7 @@ def fft_poisson(self, performance_test_flag = False):
     else:
         N_g = self.N_ghost
         rho =   self.physical_system.params.charge_electron \
-              * self.compute_moments('density')[N_g:-N_g, N_g:-N_g]
+              * (self.compute_moments('density')[N_g:-N_g, N_g:-N_g])
 
         k_q1 = fftfreq(rho.shape[0], self.dq1)
         k_q2 = fftfreq(rho.shape[1], self.dq2)

--- a/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
+++ b/bolt/lib/nonlinear_solver/EM_fields_solver/electrostatic.py
@@ -90,6 +90,7 @@ def compute_electrostatic_fields(self, performance_test_flag = False):
                       )
            )
 
+    ksp.setFromOptions()
     ksp.solve(rho, phi)
 
     num_tries = 0

--- a/bolt/lib/nonlinear_solver/nonlinear_solver.py
+++ b/bolt/lib/nonlinear_solver/nonlinear_solver.py
@@ -143,16 +143,16 @@ class nonlinear_solver(object):
 
         # Additionally, a DA object also needs to be created for the KSP solver
         # with a DOF of 1:
-        self._da_ksp = PETSc.DMDA().create([self.N_q1, self.N_q2],
-                                            stencil_width = self.N_ghost,
-                                            boundary_type = (self.bc_in_q1,
-                                                             self.bc_in_q2
-                                                            ),
-                                            proc_sizes    = (PETSc.DECIDE,
-                                                             PETSc.DECIDE
-                                                            ),
-                                            stencil_type  = 1,
-                                            comm          = self._comm)
+        self._da_snes = PETSc.DMDA().create([self.N_q1, self.N_q2],
+                                             stencil_width = self.N_ghost,
+                                             boundary_type = (self.bc_in_q1,
+                                                              self.bc_in_q2
+                                                             ),
+                                             proc_sizes    = (PETSc.DECIDE,
+                                                              PETSc.DECIDE
+                                                             ),
+                                             stencil_type  = 1,
+                                             comm          = self._comm)
 
         self._da_dump_moments = PETSc.DMDA().create([self.N_q1, self.N_q2],
                                                     dof        = len(self.
@@ -174,6 +174,12 @@ class nonlinear_solver(object):
         # the communication routines for EM fields
         self._glob_fields  = self._da_fields.createGlobalVec()
         self._local_fields = self._da_fields.createLocalVec()
+    
+        self.glob_phi      = self._da_snes.createGlobalVec()
+        self.glob_residual = self._da_snes.createGlobalVec()
+        self.glob_phi.set(0.)
+        self.glob_residual.set(0.)
+
 
         # The following vector is used to dump the data to file:
         self._glob_moments = self._da_dump_moments.createGlobalVec()

--- a/bolt/lib/nonlinear_solver/nonlinear_solver.py
+++ b/bolt/lib/nonlinear_solver/nonlinear_solver.py
@@ -152,6 +152,7 @@ class nonlinear_solver(object):
                                                               PETSc.DECIDE
                                                              ),
                                              stencil_type  = 1,
+                                             dof = 1,
                                              comm          = self._comm)
 
         self._da_dump_moments = PETSc.DMDA().create([self.N_q1, self.N_q2],

--- a/bolt/lib/nonlinear_solver/tests/test_3D_poisson_solver_2D_density.py
+++ b/bolt/lib/nonlinear_solver/tests/test_3D_poisson_solver_2D_density.py
@@ -1,0 +1,234 @@
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import petsc4py, sys
+petsc4py.init(sys.argv)
+from petsc4py import PETSc
+import arrayfire as af
+import numpy as np
+import pylab as pl
+
+pl.rcParams['figure.figsize']  = 17, 7.5
+pl.rcParams['figure.dpi']      = 150
+pl.rcParams['image.cmap']      = 'jet'
+pl.rcParams['lines.linewidth'] = 1.5
+pl.rcParams['font.family']     = 'serif'
+pl.rcParams['font.weight']     = 'bold'
+pl.rcParams['font.size']       = 20
+pl.rcParams['font.sans-serif'] = 'serif'
+pl.rcParams['text.usetex']     = True
+pl.rcParams['axes.linewidth']  = 1.5
+pl.rcParams['axes.titlesize']  = 'medium'
+pl.rcParams['axes.labelsize']  = 'medium'
+
+pl.rcParams['xtick.major.size'] = 8
+pl.rcParams['xtick.minor.size'] = 4
+pl.rcParams['xtick.major.pad']  = 8
+pl.rcParams['xtick.minor.pad']  = 8
+pl.rcParams['xtick.color']      = 'k'
+pl.rcParams['xtick.labelsize']  = 'medium'
+pl.rcParams['xtick.direction']  = 'in'
+
+pl.rcParams['ytick.major.size'] = 8
+pl.rcParams['ytick.minor.size'] = 4
+pl.rcParams['ytick.major.pad']  = 8
+pl.rcParams['ytick.minor.pad']  = 8
+pl.rcParams['ytick.color']      = 'k'
+pl.rcParams['ytick.labelsize']  = 'medium'
+pl.rcParams['ytick.direction']  = 'in'
+
+comm = PETSc.COMM_WORLD.tompi4py()
+
+N_q1_poisson = 70
+N_q2_poisson = 70
+N_q3_poisson = 70
+
+N_q1_density = 35
+N_q2_density = 35
+
+N_ghost = 3
+
+da_3D = PETSc.DMDA().create([N_q1_poisson,
+                             N_q2_poisson,
+                             N_q3_poisson],
+                             stencil_width = N_ghost,
+                             boundary_type = ('periodic',
+                                              'periodic',
+                                              'periodic'
+                                             ),
+                              stencil_type = 1,
+                              dof          = 1,
+                              comm         = comm
+                           )
+
+glob_phi      = da_3D.createGlobalVec()
+local_phi     = da_3D.createLocalVec()
+glob_residual = da_3D.createGlobalVec()
+
+((i_q1_3D_start, i_q2_3D_start, i_q3_3D_start),
+ (N_q1_3D_local, N_q2_3D_local, N_q3_3D_local)
+) = \
+    da_3D.getCorners()
+
+q1_3D_start = -2.; q1_3D_end = 2.
+q2_3D_start = -2.; q2_3D_end = 2.
+q3_3D_start =  0.; q3_3D_end = 2.
+
+dq1_3D = (q1_3D_end - q1_3D_start) / N_q1_poisson
+dq2_3D = (q2_3D_end - q2_3D_start) / N_q2_poisson
+dq3_3D = (q3_3D_end - q3_3D_start) / N_q3_poisson
+
+i_q1_3D = ( (i_q1_3D_start + 0.5)
+           + np.arange(-N_ghost, N_q1_3D_local + N_ghost)
+          )
+
+i_q2_3D = ( (i_q2_3D_start + 0.5)
+           + np.arange(-N_ghost, N_q2_3D_local + N_ghost)
+          )
+
+i_q3_3D = ( (i_q3_3D_start + 0.5)
+           + np.arange(-N_ghost, N_q3_3D_local + N_ghost)
+          )
+
+q1_3D =  q1_3D_start + i_q1_3D * dq1_3D
+q2_3D =  q2_3D_start + i_q2_3D * dq2_3D
+q3_3D =  q3_3D_start + i_q3_3D * dq3_3D
+
+da_2D = PETSc.DMDA().create([N_q1_density,
+                             N_q2_density],
+                             stencil_width = N_ghost,
+                             boundary_type = ('periodic',
+                                              'periodic'
+                                             ),
+                             stencil_type = 1,
+                             dof          = 1,
+                             comm         = comm
+                           )
+
+glob_density  = da_2D.createGlobalVec()
+local_density = da_2D.createLocalVec()
+
+
+((i_q1_2D_start, i_q2_2D_start), 
+ (N_q1_2D_local, N_q2_2D_local)
+) = \
+    da_2D.getCorners()
+
+q1_2D_start = -1.; q1_2D_end = 1.
+q2_2D_start = -1.; q2_2D_end = 1.
+location_in_q3 = 1.
+
+dq1_2D = (q1_2D_end - q1_2D_start) / N_q1_density
+dq2_2D = (q2_2D_end - q2_2D_start) / N_q2_density
+
+i_q1_2D = ( (i_q1_2D_start + 0.5)
+           + np.arange(-N_ghost, N_q1_2D_local + N_ghost)
+          )
+
+i_q2_2D = ( (i_q2_2D_start + 0.5)
+           + np.arange(-N_ghost, N_q2_2D_local + N_ghost)
+          )
+
+q1_2D =  q1_2D_start + i_q1_2D * dq1_2D
+q2_2D =  q2_2D_start + i_q2_2D * dq2_2D
+
+glob_density_array = glob_density.getArray(readonly=0)
+glob_density_array = glob_density_array.reshape([N_q2_2D_local, \
+                                                 N_q1_2D_local, 1], \
+                                               )
+glob_density_array[:] = 1.
+
+da_2D.globalToLocal(glob_density, local_density)
+
+density_array = local_density.getArray(readonly=0)
+density_array = density_array.reshape([N_q2_2D_local + 2*N_ghost, \
+                                       N_q1_2D_local + 2*N_ghost, 1], \
+                                     )
+
+print("rank = ", comm.rank)
+
+# Figure out the coordinates of the 3D phi cube of the current rank
+print("q1_3D_start = ", q1_3D[N_ghost])
+print("q2_3D_start = ", q2_3D[N_ghost])
+print("q3_3D_start = ", q3_3D[N_ghost])
+print(" ")
+print("q1_2D_start = ", q1_2D[N_ghost])
+print("q2_2D_start = ", q2_2D[N_ghost])
+
+q1_2D_in_3D_index_start = np.where(q1_3D > q1_2D[0]  - dq1_3D)[0][0]
+q1_2D_in_3D_index_end   = np.where(q1_3D < q1_2D[-1] + dq1_3D)[0][-1]
+q2_2D_in_3D_index_start = np.where(q2_3D > q2_2D[0]  - dq2_3D)[0][0]
+q2_2D_in_3D_index_end   = np.where(q2_3D < q2_2D[-1] + dq2_3D)[0][-1]
+q3_2D_in_3D_index_start = np.where(q3_3D > location_in_q3 - dq3_3D)[0][0]
+q3_2D_in_3D_index_end   = np.where(q3_3D < location_in_q3 + dq3_3D)[0][-1]
+
+print("q1_2D_in_3D_index_start = ", q1_2D_in_3D_index_start, "q1_3D_start = ", q1_3D[q1_2D_in_3D_index_start])
+print("q1_2D_in_3D_index_end   = ", q1_2D_in_3D_index_end, "q1_3D_end   = ", q1_3D[q1_2D_in_3D_index_end])
+print("q2_2D_in_3D_index_start = ", q2_2D_in_3D_index_start, "q2_3D_start = ", q2_3D[q2_2D_in_3D_index_start])
+print("q2_2D_in_3D_index_end   = ", q2_2D_in_3D_index_end, "q2_3D_end   = ", q2_3D[q2_2D_in_3D_index_end])
+print("q3_2D_in_3D_index_start = ", q3_2D_in_3D_index_start, "q3_3D_start = ", q3_3D[q3_2D_in_3D_index_start])
+print("q3_2D_in_3D_index_end   = ", q3_2D_in_3D_index_end, "q3_3D_end   = ", q3_3D[q3_2D_in_3D_index_end])
+
+class poisson_eqn(object):
+
+    def __init__(self):
+        self.local_phi = local_phi
+
+    def compute_residual(self, snes, phi, residual):
+        da_3D.globalToLocal(phi, local_phi)
+
+        N_g = N_ghost
+
+        phi_array = local_phi.getArray(readonly=0)
+        phi_array = phi_array.reshape([N_q3_3D_local + 2*N_g, \
+                                       N_q2_3D_local + 2*N_g, \
+                                       N_q1_3D_local + 2*N_g, 1
+        			      ]
+                                     )
+    
+        residual_array = residual.getArray(readonly=0)
+        residual_array = residual_array.reshape([N_q3_3D_local, \
+                                                 N_q2_3D_local, \
+                                                 N_q1_3D_local, 1
+        					]
+                                               )
+
+        phi_array[:N_ghost, :, :]               = 0.
+        phi_array[N_q1_3D_local+N_ghost:, :, :] = 0.
+        phi_array[:, :N_ghost, :]               = 0.
+        phi_array[:, N_q2_3D_local+N_ghost:, :] = 0.
+        phi_array[:, :, :N_ghost]               = 0.
+        phi_array[:, :, N_q3_3D_local+N_ghost:] = 0.
+
+        phi_plus_x  = np.roll(phi_array, shift=-1, axis=2)
+        phi_minus_x = np.roll(phi_array, shift=1,  axis=2)
+        phi_plus_y  = np.roll(phi_array, shift=-1, axis=1)
+        phi_minus_y = np.roll(phi_array, shift=1,  axis=1)
+        phi_plus_z  = np.roll(phi_array, shift=-1, axis=0)
+        phi_minus_z = np.roll(phi_array, shift=1,  axis=0)
+
+        d2phi_dx2   = (phi_minus_x - 2.*phi_array + phi_plus_x)/dq1_3D**2.
+        d2phi_dy2   = (phi_minus_y - 2.*phi_array + phi_plus_y)/dq2_3D**2.
+        d2phi_dz2   = (phi_minus_z - 2.*phi_array + phi_plus_z)/dq3_3D**2.
+        
+        laplacian_phi = d2phi_dx2 + d2phi_dy2 + d2phi_dz2
+
+        laplacian_phi[q3_2D_in_3D_index_start:q3_2D_in_3D_index_end,
+                      q2_2D_in_3D_index_start:q2_2D_in_3D_index_end,
+                      q1_2D_in_3D_index_start:q1_2D_in_3D_index_end
+                     ] \
+                     += density_array
+
+        residual_array[:, :, :] = \
+            laplacian_phi[N_g:-N_g, N_g:-N_g, N_g:-N_g]
+
+        return
+
+snes = PETSc.SNES().create()
+pde  = poisson_eqn()
+snes.setFunction(pde.compute_residual, glob_residual)
+
+snes.setDM(da_3D)
+snes.setFromOptions()
+snes.solve(None, glob_phi)

--- a/bolt/lib/nonlinear_solver/tests/test_af_np_petsc_data_transfer.py
+++ b/bolt/lib/nonlinear_solver/tests/test_af_np_petsc_data_transfer.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import arrayfire as af
+import petsc4py, sys
+petsc4py.init(sys.argv)
+from petsc4py import PETSc
+
+N_q1    = 64
+N_q2    = 128
+N_q3    = 96
+dof     = 16*16*16
+N_ghost = 3
+print("---------------------")
+print("N_q1 + 2*N_ghost =", N_q1 + 2*N_ghost) 
+print("N_q2 + 2*N_ghost =", N_q2 + 2*N_ghost) 
+print("N_q3 + 2*N_ghost =", N_q3 + 2*N_ghost) 
+print("dof              =", dof)
+print("---------------------\n")
+
+da = PETSc.DMDA().create([N_q1, N_q2],
+                          stencil_width=N_ghost,
+                          boundary_type=('periodic',
+                                         'periodic'),
+                          stencil_type=1,
+                          dof = dof
+                        )
+
+glob_vec  = da.createGlobalVec() # No ghost zones in [N_q1, N_q2]
+local_vec = da.createLocalVec()  # Has ghost zones in [N_q1, N_q2]
+
+# Initialize glob_vec to random numbers
+glob_vec.setRandom()
+
+local_vec_array_old = da.getVecArray(local_vec)
+glob_vec_array_old  = da.getVecArray(glob_vec)
+
+#1d np arrays pointing to respective vecs
+local_vec_array  = local_vec.getArray()
+global_vec_array = glob_vec.getArray()
+
+((i_q1_start, i_q2_start), (N_q1_local, N_q2_local)) = da.getCorners()
+
+af_array_old = af.randu(N_q1_local+2*N_ghost,
+			N_q2_local+2*N_ghost,
+			dof,
+                        dtype=af.Dtype.f64
+		       )
+af.eval(af_array_old)
+
+af_array_new = af.randu(dof, 
+                        N_q1_local+2*N_ghost,
+			N_q2_local+2*N_ghost,
+                        dtype=af.Dtype.f64
+		       )
+af.eval(af_array_new)
+af.sync()
+
+print("af_array_old.shape = ", af_array_old.shape)
+print("af_array_new.shape = ", af_array_new.shape)
+
+def communicate_old(af_array, da, glob_vec, local_vec):
+    # af_array is (N_q2+2*N_ghost, N_q1+2*N_ghost, dof)
+
+    # Global value is non-inclusive of the ghost-zones:
+    glob_vec_array_old[:] = np.array(af_array[N_ghost:-N_ghost, 
+                                              N_ghost:-N_ghost
+                                             ]
+                                    )
+    
+    # The following function takes care of periodic boundary conditions,
+    # and interzonal communications:
+    da.globalToLocal(glob_vec, local_vec)
+
+    # Converting back from PETSc.Vec to af.Array:
+    af_array_after_comm = af.to_array(local_vec_array_old[:])
+
+    af.eval(af_array_after_comm)
+
+    return(af_array_after_comm)
+
+def communicate_new(af_array, da, glob_vec, local_vec):
+    # af_array is (dof, N_q1, N_q2)
+    
+    # First flatten af_array
+    af_array_1d = af.moddims(af_array[:, 
+                                      N_ghost:-N_ghost,
+                                      N_ghost:-N_ghost
+				     ],
+                               N_q1_local 
+			     * N_q2_local
+			     * dof
+                            )
+    
+    # Convert to a np array and copy to petsc
+    global_vec_array[:] = af_array_1d.to_ndarray()
+
+    # Communication: Global -> Local
+    da.globalToLocal(glob_vec, local_vec)
+
+    # loval_vec_array_new now has the data. Need to convert to af
+    af_array_after_comm_1d = af.to_array(local_vec_array)
+    af_array_after_comm    = af.moddims(af_array_after_comm_1d,
+                                        dof,
+                                        N_q1_local + 2*N_ghost,
+                                        N_q2_local + 2*N_ghost
+                                       )
+
+    af.eval(af_array_after_comm)
+
+    return(af_array_after_comm)
+
+communicate_old(af_array_old, da, glob_vec, local_vec)
+communicate_new(af_array_new, da, glob_vec, local_vec)
+af.sync()
+
+iters = 1
+
+tic_old = af.time()
+for n in range(iters):
+    communicate_old(af_array_old, da, glob_vec, local_vec)
+af.sync()
+toc_old = af.time()
+time_old = toc_old - tic_old
+
+tic_new = af.time()
+for n in range(iters):
+    communicate_new(af_array_new, da, glob_vec, local_vec)
+af.sync()
+toc_new = af.time()
+time_new = toc_new - tic_new
+
+print(" ")
+print("comm_old = ", format(time_old/iters, '.4f'), "secs/iter")
+print("comm_new = ", format(time_new/iters, '.4f'), "secs/iter")
+print(" ")
+
+## Now need to transfer data from glob_vec to local_vec
+#da.globalToLocal(glob_vec, local_vec)
+## Communication complete. All interprocessor ghost zones in local_vec are
+## now filled.
+#
+## Problem statement: Accessing local_vec using numpy arrays
+## ---------- Method 1----------- 
+#local_array_method_1 = da.getVecArray(local_vec)
+#
+## Note: da.getVecArray() does NOT return a numpy array
+##       local_array_method_1[:] is a numpy array
+#local_array_method_1_np = local_array_method_1[:]
+#
+#print("---------------------")
+#print("local_array_method_1_np.shape   = ", local_array_method_1_np.shape)
+#print("local_array_method_1_np.strides = ", local_array_method_1_np.strides)
+#print("---------------------\n")
+#
+## ---------- Method 2----------- 
+#local_array_method_2_np = local_vec.getArray()
+#
+## Note: local_vec.getArray() *directly* returns a numpy array of shape 1D and
+## size (N_q1 + 2*N_ghost) x (N_q2 + 2*N_ghost) * dof
+#
+#print("---------------------")
+#print("local_array_method_2_np.shape   = ", local_array_method_2_np.shape)
+#print("local_array_method_2_np.strides = ", local_array_method_2_np.strides)
+#print("---------------------\n")
+#
+## Now need to reshape
+#local_array_method_2_np_reshaped = \
+#        local_array_method_2_np.reshape([N_q2+2*N_ghost,
+#                                         N_q1+2*N_ghost,
+#                                         dof
+#                                        ]
+#                                       )
+#print("---------------------")
+#print("local_array_method_2_np_reshaped.shape   = ", \
+#        local_array_method_2_np_reshaped.shape)
+#print("local_array_method_2_np_reshaped.strides = ", \
+#        local_array_method_2_np_reshaped.strides)
+#print("---------------------\n")
+#
+#print("Conclusion:")
+#print(" * Natural order is set by PETSc where dof is the fastest index and q2 is the slowest index")
+#print(" * Optimal layout for np arrays is (q2, q1, dof)")
+#print(" * Optimal layout for af arrays is (dof, q1, q2)\n")
+#
+## Strategy for efficient af<->PETSc transfer:
+## 1) We need to transfer data from array_af with dims (dof, N_q1, N_q2) to a PETSc vec: glob_vec
+## 2) Reshape it into 1D : array_af_1d
+## 2) Get the associated 1d np array of glob_vec: glob_array = glob_vec.getArray()
+## 3) Fast transfer to np (and hence to PETSc): array_af_1d.to_ndarray(glob_array_np)
+## 4) Done! : glob_vec now has data from af_array
+## 5) Now perform globalToLocal(glob_vec, local_vec)
+## 6) Get 1d np array: local_array = local_vec.getArray()
+## 7) Transfer data from 1d np array to 1d af array: af_array_ghosted_1d = af.to_array(local_array)
+## 8) Reshape af_array_ghosted_1d to dims (dof, N_q1+2*N_ghost, N_q2+2*N_ghost)
+#
+#local_array_method_2_af = af.to_array(local_array_method_2_np_reshaped)
+#print("---------------------")
+#print("local_array_method_2_af.shape   = ", local_array_method_2_af.shape)
+#print("local_array_method_2_af.strides = ", local_array_method_2_af.strides())
+#print("---------------------\n")
+#
+#local_array_method_2_af_reshaped = af.to_array(local_array_method_2_np)
+#local_array_method_2_af_reshaped = af.moddims(local_array_method_2_af_reshaped,
+#                                              dof,
+#                                              N_q1+2*N_ghost,
+#                                              N_q2+2*N_ghost
+#                                             )
+#
+#print("---------------------")
+#print("local_array_method_2_af_reshaped.shape   = ",
+#        local_array_method_2_af_reshaped.shape)
+#print("local_array_method_2_af_reshaped.strides = ",
+#        local_array_method_2_af_reshaped.strides())
+#print("---------------------\n")
+#
+#local_array_af_to_np = local_array_method_2_af.to_ndarray()
+#print("---------------------")
+#print("local_array_af_to_np.shape   = ", local_array_af_to_np.shape)
+#print("local_array_af_to_np.strides = ", local_array_af_to_np.strides)
+#print("---------------------\n")
+
+#da = PETSc.DMDA().create([N_q1, N_q2, N_q3],
+#                          stencil_width=N_ghost,
+#                          boundary_type=('periodic',
+#                                         'periodic',
+#					 'periodic'),
+#                          stencil_type=1,
+#                          dof = dof
+#                        )
+#
+#glob_vec  = da.createGlobalVec() # No ghost zones in [N_q1, N_q2]
+#local_vec = da.createLocalVec()  # Has ghost zones in [N_q1, N_q2]
+#
+## Initialize glob_vec to random numbers
+#glob_vec.setRandom()
+#
+## Now need to transfer data from glob_vec to local_vec
+#da.globalToLocal(glob_vec, local_vec)
+## Communication complete. All interprocessor ghost zones in local_vec are
+## now filled.
+#
+## Problem statement: Accessing local_vec using numpy arrays
+## ---------- Method 1----------- 
+#local_array_method_1 = da.getVecArray(local_vec)
+#
+## Note: da.getVecArray() does NOT return a numpy array
+##       local_array_method_1[:] is a numpy array
+#local_array_method_1_np = local_array_method_1[:]
+#
+#print("---------------------")
+#print("local_array_method_1_np.shape   = ", local_array_method_1_np.shape)
+#print("local_array_method_1_np.strides = ", local_array_method_1_np.strides)
+#print("---------------------\n")
+#
+## ---------- Method 2----------- 
+#local_array_method_2_np = local_vec.getArray()
+#
+## Note: local_vec.getArray() *directly* returns a numpy array of shape 1D and
+## size (N_q1 + 2*N_ghost) x (N_q2 + 2*N_ghost) * dof
+#
+#print("---------------------")
+#print("local_array_method_2_np.shape   = ", local_array_method_2_np.shape)
+#print("local_array_method_2_np.strides = ", local_array_method_2_np.strides)
+#print("---------------------\n")
+#
+## Now need to reshape
+#local_array_method_2_np_reshaped = \
+#        local_array_method_2_np.reshape([N_q3+2*N_ghost,
+#	                                 N_q2+2*N_ghost,
+#                                         N_q1+2*N_ghost,
+#                                         dof
+#                                        ]
+#                                       )
+#print("---------------------")
+#print("local_array_method_2_np_reshaped.shape   = ", \
+#        local_array_method_2_np_reshaped.shape)
+#print("local_array_method_2_np_reshaped.strides = ", \
+#        local_array_method_2_np_reshaped.strides)
+#print("---------------------\n")
+#
+#print("Conclusion:")
+#print(" * Natural order is set by PETSc where dof is the fastest index and q2 is the slowest index")
+#print(" * Optimal layout for np arrays is (q3, q2, q1, dof)")
+#print(" * Optimal layout for af arrays is (dof, q1, q2, q3)\n")

--- a/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
+++ b/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
@@ -13,7 +13,10 @@ given by the KSP solver
 
 import numpy as np
 import arrayfire as af
+import petsc4py, sys
+petsc4py.init(sys.argv)
 from petsc4py import PETSc
+
 
 from bolt.lib.nonlinear_solver.EM_fields_solver.electrostatic \
     import compute_electrostatic_fields
@@ -143,7 +146,10 @@ def test_compute_electrostatic_fields_2():
         obj = test(N[i])
         compute_electrostatic_fields(obj)
 
-        E1_expected = 0
+        E1_expected = 0 * obj.q1
+        
+        q2_minus = 0.25
+        q2_plus  = 0.75
 
         E2_expected = -0.5/20 * (  af.log(af.cosh(( obj.q2 - q2_minus)*20)) 
                                  - af.log(af.cosh(( obj.q2 - q2_plus )*20))
@@ -166,3 +172,6 @@ def test_compute_electrostatic_fields_2():
 
     assert (abs(poly_E1[0] + 2) < 0.2)
     assert (abs(poly_E2[0] + 2) < 0.2)
+
+
+test_compute_electrostatic_fields_2()

--- a/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
+++ b/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
@@ -16,13 +16,19 @@ import arrayfire as af
 import petsc4py, sys
 petsc4py.init(sys.argv)
 from petsc4py import PETSc
+import pylab as pl
 
 
 from bolt.lib.nonlinear_solver.EM_fields_solver.electrostatic \
     import compute_electrostatic_fields
 
 def compute_moments_sinusoidal(self, *args):
-    return (1 + af.sin(2 * np.pi * self.q1 + 4 * np.pi * self.q2))
+    rho = 1. + 0.1*af.sin(2 * np.pi * self.q1 + 4 * np.pi * self.q2)
+
+    rho_mean = af.mean(rho)
+    print("rho_mean = ", rho_mean)
+
+    return(rho - rho_mean)
 
 def compute_moments_gaussian(self, *args):
     q2_minus = 0.25
@@ -34,7 +40,26 @@ def compute_moments_gaussian(self, *args):
                      - af.tanh(( self.q2 - q2_plus )*regulator)
                     )
 
-    return(rho)
+#    rho =  af.exp(-0.*(self.q1 - 0.5)**2./0.01 - (self.q2 - 0.5)**2./0.01)
+#    rho = (self.q2 - 0.5)**2. + (self.q1 - 0.5)**2.
+
+#    rho = 1. + 0.1*af.sin(2*np.pi*self.q2)
+
+#    sigma = 0.1
+#    rho =  af.exp(-(self.q1)**2./(2.*sigma**2.) -(self.q2)**2./(2.*sigma**2.)) \
+#    	  * 1./ sigma**2. / (2. * np.pi)
+
+    N_g = self.N_ghost
+    net_charge = af.sum(rho[N_g:-N_g, N_g:-N_g]) * self.dq1 * self.dq2
+
+    total_volume =   (self.q1_end - self.q1_start) \
+                   * (self.q2_end - self.q2_start)
+
+    rho_zero_net_charge = rho - net_charge/total_volume
+
+    print("Initial net charge = ", net_charge)
+
+    return(rho_zero_net_charge)
 
 class test(object):
     def __init__(self, N_q1, N_q2):
@@ -45,11 +70,11 @@ class test(object):
                                     }
                                    )
 
-        self.q1_start = 0
-        self.q2_start = 0
+        self.q1_start = 0.
+        self.q2_start = 0.
 
-        self.q1_end = 1
-        self.q2_end = 1
+        self.q1_end = 1.
+        self.q2_end = 1.
 
         self.N_q1 = N_q1
         self.N_q2 = N_q2
@@ -99,26 +124,18 @@ class test(object):
         self.glob_phi  = self._da_snes.createGlobalVec()
         self.glob_phi.set(0.)
 
-        self._da_test = PETSc.DMDA().create([self.N_q1, self.N_q2],
-                                            stencil_width=self.N_ghost,
-                                            boundary_type=('ghosted',
-                                                           'ghosted'),
-                                            stencil_type=1,
-                                            dof = 1
-                                           )
-        self.glob_vec  = self._da_test.createGlobalVec()
+    compute_moments = compute_moments_gaussian
 
-    compute_moments = compute_moments_sinusoidal
+def test_compute_electrostatic_fields_1():
+    obj = test(70, 70)
+    compute_electrostatic_fields(obj)
 
-#def test_compute_electrostatic_fields_1():
-#
-#    error_E1 = np.zeros(5)
-#    error_E2 = np.zeros(5)
-#
-#    N = 2**np.arange(5, 10)
+#    N = 7*np.array([2, 4, 6, 8, 10, 12])
+#    error_E1 = np.zeros(N.size)
+#    error_E2 = np.zeros(N.size)
 #
 #    for i in range(N.size):
-#        obj = test(N[i])
+#        obj = test(N[i], N[i])
 #        compute_electrostatic_fields(obj)
 #
 #        E1_expected =    (0.1 / np.pi) \
@@ -143,6 +160,9 @@ class test(object):
 #                                   )
 #                            ) / (obj.E2[N_g:-N_g, N_g:-N_g].elements())
 #
+#    print("Error E1 = ", error_E1)
+#    print("Error E2 = ", error_E2)
+#
 #    poly_E1 = np.polyfit(np.log10(N), np.log10(error_E1), 1)
 #    poly_E2 = np.polyfit(np.log10(N), np.log10(error_E2), 1)
 #
@@ -151,54 +171,44 @@ class test(object):
 
 def test_compute_electrostatic_fields_2():
 
-    error_E1 = np.zeros(5)
-    error_E2 = np.zeros(5)
+    N = 7*np.array([2, 4, 6, 8, 10, 12])
+    N = 7*np.array([12])
+    error_E1 = np.zeros(N.size)
+    error_E2 = np.zeros(N.size)
 
-    obj = test(14, 7)
-    compute_electrostatic_fields(obj)
-#    print(obj.glob_phi.getArray().reshape([49, 35], order='A').strides)
-#    print(obj.glob_vec.getArray().reshape([49, 35, 10], order='A').strides)
+    for i in range(N.size):
+        obj = test(N[i], N[i])
+        compute_electrostatic_fields(obj)
 
-#    obj.glob_vec.set(3.)
-#    local_vec = obj._da_test.createLocalVec()
-#    obj._da_test.globalToLocal(obj.glob_vec, local_vec)
-#    local_vec_array_direct = local_vec.getArray().reshape([7 + 6, 14+6, 2],
-#            order='c')
-#    print(local_vec_array_direct)
-#    print(local_vec_array_direct.strides)
+        E1_expected = 0 * obj.q1
+        
+        q2_minus = 0.25
+        q2_plus  = 0.75
 
-#    N = 2**np.arange(5, 10)
-#
-#    for i in range(N.size):
-#        obj = test(N[i])
-#        compute_electrostatic_fields(obj)
-#
-#        E1_expected = 0 * obj.q1
-#        
-#        q2_minus = 0.25
-#        q2_plus  = 0.75
-#
-#        E2_expected = -0.5/20 * (  af.log(af.cosh(( obj.q2 - q2_minus)*20)) 
-#                                 - af.log(af.cosh(( obj.q2 - q2_plus )*20))
-#                                ) 
-#
-#        N_g = obj.N_ghost
-#
-#        error_E1[i] = af.sum(af.abs(  obj.E1[N_g:-N_g, N_g:-N_g]
-#                                    - E1_expected[N_g:-N_g, N_g:-N_g]
-#                                   )
-#                            ) / (obj.E1[N_g:-N_g, N_g:-N_g].elements())
-#
-#        error_E2[i] = af.sum(af.abs(  obj.E2[N_g:-N_g, N_g:-N_g]
-#                                    - E2_expected[N_g:-N_g, N_g:-N_g]
-#                                   )
-#                            ) / (obj.E2[N_g:-N_g, N_g:-N_g].elements())
-#
-#    poly_E1 = np.polyfit(np.log10(N), np.log10(error_E1), 1)
-#    poly_E2 = np.polyfit(np.log10(N), np.log10(error_E2), 1)
-#
-#    assert (abs(poly_E1[0] + 2) < 0.2)
-#    assert (abs(poly_E2[0] + 2) < 0.2)
+        E2_expected = -0.5/20 * (  af.log(af.cosh(( obj.q2 - q2_minus)*20)) 
+                                 - af.log(af.cosh(( obj.q2 - q2_plus )*20))
+                                ) 
+
+        N_g = obj.N_ghost
+
+        error_E1[i] = af.sum(af.abs(  obj.E1[N_g:-N_g, N_g:-N_g]
+                                    - E1_expected[N_g:-N_g, N_g:-N_g]
+                                   )
+                            ) / (obj.E1[N_g:-N_g, N_g:-N_g].elements())
+
+        error_E2[i] = af.sum(af.abs(  obj.E2[N_g:-N_g, N_g:-N_g]
+                                    - E2_expected[N_g:-N_g, N_g:-N_g]
+                                   )
+                            ) / (obj.E2[N_g:-N_g, N_g:-N_g].elements())
+
+    print("Error E1 = ", error_E1)
+    print("Error E2 = ", error_E2)
+
+    poly_E1 = np.polyfit(np.log10(N), np.log10(error_E1), 1)
+    poly_E2 = np.polyfit(np.log10(N), np.log10(error_E2), 1)
+
+    assert (abs(poly_E1[0] + 2) < 0.2)
+    assert (abs(poly_E2[0] + 2) < 0.2)
 
 
 test_compute_electrostatic_fields_2()

--- a/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
+++ b/bolt/lib/nonlinear_solver/tests/test_compute_electrostatic_fields.py
@@ -18,6 +18,20 @@ from petsc4py import PETSc
 from bolt.lib.nonlinear_solver.EM_fields_solver.electrostatic \
     import compute_electrostatic_fields
 
+def compute_moments_sinusoidal(self, *args):
+    return (1 + af.sin(2 * np.pi * self.q1 + 4 * np.pi * self.q2))
+
+def compute_moments_gaussian(self, *args):
+    q2_minus = 0.25
+    q2_plus  = 0.75
+
+    regulator = 20  # larger value makes the transition sharper
+
+    rho = 1 + 0.5 * (  af.tanh(( self.q2 - q2_minus)*regulator) 
+                     - af.tanh(( self.q2 - q2_plus )*regulator)
+                    )
+
+    return(rho)
 
 class test(object):
     def __init__(self, N):
@@ -77,11 +91,9 @@ class test(object):
                                             stencil_type=1,
                                           )
 
-    def compute_moments(self, *args):
-        return (1 + af.sin(2 * np.pi * self.q1 + 4 * np.pi * self.q2))
+    compute_moments = compute_moments_sinusoidal
 
-
-def test_compute_electrostatic_fields():
+def test_compute_electrostatic_fields_1():
 
     error_E1 = np.zeros(5)
     error_E2 = np.zeros(5)
@@ -101,6 +113,41 @@ def test_compute_electrostatic_fields():
                       * af.cos(  2 * np.pi * obj.q1
                                + 4 * np.pi * obj.q2
                               )
+
+        N_g = obj.N_ghost
+
+        error_E1[i] = af.sum(af.abs(  obj.E1[N_g:-N_g, N_g:-N_g]
+                                    - E1_expected[N_g:-N_g, N_g:-N_g]
+                                   )
+                            ) / (obj.E1[N_g:-N_g, N_g:-N_g].elements())
+
+        error_E2[i] = af.sum(af.abs(  obj.E2[N_g:-N_g, N_g:-N_g]
+                                    - E2_expected[N_g:-N_g, N_g:-N_g]
+                                   )
+                            ) / (obj.E2[N_g:-N_g, N_g:-N_g].elements())
+
+    poly_E1 = np.polyfit(np.log10(N), np.log10(error_E1), 1)
+    poly_E2 = np.polyfit(np.log10(N), np.log10(error_E2), 1)
+
+    assert (abs(poly_E1[0] + 2) < 0.2)
+    assert (abs(poly_E2[0] + 2) < 0.2)
+
+def test_compute_electrostatic_fields_2():
+
+    error_E1 = np.zeros(5)
+    error_E2 = np.zeros(5)
+
+    N = 2**np.arange(5, 10)
+
+    for i in range(N.size):
+        obj = test(N[i])
+        compute_electrostatic_fields(obj)
+
+        E1_expected = 0
+
+        E2_expected = -0.5/20 * (  af.log(af.cosh(( obj.q2 - q2_minus)*20)) 
+                                 - af.log(af.cosh(( obj.q2 - q2_plus )*20))
+                                ) 
 
         N_g = obj.N_ghost
 


### PR DESCRIPTION
Transfer from af<->np<->petsc without reordering

Initial testing:

```
$ AF_OPENCL_DEFAULT_DEVICE_TYPE=CPU python test_af_np_petsc_data_transfer.py 
ArrayFire v3.6.0 (OpenCL, 64-bit Linux, build d9bc8d7)
-0- NVIDIA: Quadro M1000M, 2047 MB
[1] INTEL: Intel(R) Xeon(R) CPU E3-1505M v5 @ 2.80GHz, 31993 MB
---------------------
N_q1 + 2*N_ghost = 70
N_q2 + 2*N_ghost = 134
dof              = 4096
---------------------

af_array_old.shape =  (70, 134, 4096)
af_array_new.shape =  (4096, 70, 134)
 
comm_old =  2.8967 secs/iter
comm_new =  0.8536 secs/iter
 
```